### PR TITLE
Add environment setup script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Keep this exact structure even when no attachments are present (attachments root
    - `OPERATOR_KEY` = your private key (e.g., `302e0201...`)
    - `TOPIC_ID` = your topic ID (e.g., `0.0.1234567`)
 
+Once you have these values, run `./setup.sh` to copy `env.example` to `.env` and install any Go module dependencies.
+
 ---
 
 ## 5) Go implementation (server)

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Setup script for SurveyCTO -> Hedera Proof pipeline.
+# Copies env.example to .env and optionally installs Go dependencies.
+
+set -euo pipefail
+
+ENV_FILE=".env"
+EXAMPLE_FILE="env.example"
+
+if [ -f "$ENV_FILE" ]; then
+  echo "$ENV_FILE already exists. Skipping copy."
+else
+  if [ -f "$EXAMPLE_FILE" ]; then
+    cp "$EXAMPLE_FILE" "$ENV_FILE"
+    echo "Created $ENV_FILE from $EXAMPLE_FILE. Please edit it with your Hedera credentials."
+  else
+    echo "Example environment file $EXAMPLE_FILE not found."
+  fi
+fi
+
+if [ -f "go.mod" ]; then
+  echo "Running go mod tidy to ensure dependencies are installed..."
+  go mod tidy
+else
+  echo "No go.mod file found, skipping Go dependency installation."
+fi
+
+echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- add shell setup utility for environment variables and Go dependencies
- document setup script usage in README

## Testing
- `shellcheck setup.sh` *(fails: command not found)*
- `./setup.sh`
- `bash test.sh` *(fails: couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_b_68a41c3519c48323892a2cda18d5cfb5